### PR TITLE
Add files via upload

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -1,0 +1,98 @@
+package ginmetrics
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metric defines a metric object. Users can use it to save
+// metric data. Every metric should be globally unique by name.
+type Metric struct {
+	Type        MetricType
+	Name        string
+	Description string
+	Labels      []string
+	Buckets     []float64
+	Objectives  map[float64]float64
+
+	vec prometheus.Collector
+}
+
+// SetGaugeValue set data for Gauge type Metric.
+func (m *Metric) SetGaugeValue(labelValues []string, value float64) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+
+	if m.Type != Gauge {
+		return fmt.Errorf("metric %s not Gauge type", m.Name)
+	}
+	m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Set(value)
+	return nil
+}
+
+// Inc increments the value for Counter/Gauge type metric by 1.
+// It returns an error if the metric does not exist or is not of a valid type.
+func (m *Metric) Inc(labelValues []string) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s does not exist", m.Name)
+	}
+	if m.Type != Gauge && m.Type != Counter {
+		return fmt.Errorf("metric %s is not of type Gauge or Counter", m.Name)
+	}
+	// Use a type assertion to avoid repetitive type checks.
+	switch m.Type {
+	case Counter:
+		c, ok := m.vec.(*prometheus.CounterVec) // Type assertion to CounterVec
+		if !ok {
+			return fmt.Errorf("failed to assert metric %s as CounterVec", m.Name)
+		}
+		c.WithLabelValues(labelValues...).Inc()
+	case Gauge:
+		g, ok := m.vec.(*prometheus.GaugeVec) // Type assertion to GaugeVec
+		if !ok {
+			return fmt.Errorf("failed to assert metric %s as GaugeVec", m.Name)
+		}
+		g.WithLabelValues(labelValues...).Inc()
+	}
+	return nil
+}
+
+
+// Add adds the given value to the Metric object. Only
+// for Counter/Gauge type metric.
+func (m *Metric) Add(labelValues []string, value float64) error {
+	if m.Type == None {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+
+	if m.Type != Gauge && m.Type != Counter {
+		return fmt.Errorf("metric %s not Gauge or Counter type", m.Name)
+	}
+	switch m.Type {
+	case Counter:
+		m.vec.(*prometheus.CounterVec).WithLabelValues(labelValues...).Add(value)
+	case Gauge:
+		m.vec.(*prometheus.GaugeVec).WithLabelValues(labelValues...).Add(value)
+	}
+	return nil
+}
+
+// Observe is used by Histogram and Summary type metric to
+// add observations.
+func (m *Metric) Observe(labelValues []string, value float64) error {
+	if m.Type == 0 {
+		return fmt.Errorf("metric %s not existed", m.Name)
+	}
+	if m.Type != Histogram && m.Type != Summary {
+		return fmt.Errorf("metric %s not Histogram or Summary type", m.Name)
+	}
+	switch m.Type {
+	case Histogram:
+		m.vec.(*prometheus.HistogramVec).WithLabelValues(labelValues...).Observe(value)
+	case Summary:
+		m.vec.(*prometheus.SummaryVec).WithLabelValues(labelValues...).Observe(value)
+	}
+	return nil
+}


### PR DESCRIPTION
Improvements Made:
Clarified Error Messages: Slight changes to the error messages make them clearer. Type Assertions with Safety Check: This avoids potential panics from type assertions by checking if the assertion was successful before invoking methods on the asserted type. Consolidation of Type Handling: By using a single type assertion for each case, the code becomes cleaner and avoids redundancy. Considerations:
Ensure that the provided label values are valid for the metrics to avoid runtime panics when calling WithLabelValues. Depending on how m.vec is initialized or used, you might want to consider checking if m.vec itself is nil before doing type assertions.

### Purpose or design rationale of this PR

*Describe your change. Make sure to answer these three questions: What does this PR do? Why does it do it? How does it do it?*


### PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


### Deployment tag versioning

Has `tag` in `common/version.go` been updated or have you added `bump-version` label to this PR?

- [ ] No, this PR doesn't involve a new deployment, git tag, docker image tag
- [ ] Yes


### Breaking change label

Does this PR have the `breaking-change` label?

- [ ] No, this PR is not a breaking change
- [ ] Yes
